### PR TITLE
fix: poiema definition title mispelling

### DIFF
--- a/app/home-client.tsx
+++ b/app/home-client.tsx
@@ -53,7 +53,7 @@ export default function HomeClient({ coreValues }: HomeClientProps) {
                 <p className='font-semibold text-lg sm:text-xl md:text-2xl leading-normal'>
                   poiema
                 </p>
-                <p className='italic leading-normal'>poy&apos;-ah-meh</p>
+                <p className='italic leading-normal'>poy&apos;-ah-mah</p>
                 <p className='font-semibold leading-normal'>
                   Greek word for workmanship or masterpiece
                 </p>


### PR DESCRIPTION
as per title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the displayed pronunciation of `poiema` on the home page.
> 
> - Updates `app/home-client.tsx` definition section, changing pronunciation from `poy'-ah-meh` to `poy'-ah-mah`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de3b573e71df14d1964ccab01ab484fe1aa3a6eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->