### PR TITLE
feat: volleyball team in meet our teams page

### DIFF
--- a/__tests__/app/teams/page.test.tsx
+++ b/__tests__/app/teams/page.test.tsx
@@ -145,4 +145,27 @@ describe('Teams Page', () => {
     expect(screen.getByTestId('team-member-1')).toBeInTheDocument();
     expect(screen.getByTestId('team-member-2')).toBeInTheDocument();
   });
+
+  it('should display Volleyball Team Leaders section when members are available', async () => {
+    const mockTeamMembers = [
+      {
+        _id: '1',
+        name: 'Volleyball Leader',
+        team: ['Volleyball'],
+      },
+    ];
+
+    mockClient.fetch.mockResolvedValue(mockTeamMembers as never);
+
+    const component = await Teams();
+    render(component);
+
+    expect(screen.getByText('Volleyball Team Leaders')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The Volleyball Team Leaders foster Christian fellowship and community through the sport of volleyball/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('team-member-1')).toBeInTheDocument();
+  });
 });

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -14,11 +14,11 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = {
   title: 'Meet Our Teams',
   description:
-    'Meet the dedicated team members serving at Poiema Ministries. Our teams include Worship, Welcoming, Media, Outreach, and more, all working together to serve our community.',
+    'Meet the dedicated team members serving at Poiema Ministries. Our teams include Worship, Welcoming, Media, Outreach, Volleyball, and more, all working together to serve our community.',
   openGraph: {
     title: 'Meet Our Teams | Poiema Ministries',
     description:
-      'Meet the dedicated team members serving at Poiema Ministries. Our teams include Worship, Welcoming, Media, Outreach, and more, all working together to serve our community.',
+      'Meet the dedicated team members serving at Poiema Ministries. Our teams include Worship, Welcoming, Media, Outreach, Volleyball, and more, all working together to serve our community.',
   },
 };
 
@@ -65,6 +65,12 @@ const TEAMS = [
     queryValue: 'Event',
     description:
       "The Outreach Team organizes events and initiatives that extend our ministry beyond our church walls, sharing the Gospel message with our broader community. They serve as ambassadors of Christ's love, demonstrating God's grace through service and creating opportunities for others to experience His transformative power.",
+  },
+  {
+    displayName: 'Volleyball Team Leaders',
+    queryValue: 'Volleyball',
+    description:
+      "The Volleyball Team Leaders foster Christian fellowship and community through the sport of volleyball. They organize practices, build team unity, and lead our ministry in annual church volleyball tournaments. Through their leadership, they create opportunities for members to grow in relationship with one another while glorifying God through healthy competition and teamwork.",
   },
 ] as const;
 


### PR DESCRIPTION
addressing issue: https://github.com/Poiema-Ministries/church-website/issues/18

added our volleyball leaders to the meet our teams page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new team section and updates metadata copy; minimal logic change and covered by a straightforward UI test.
> 
> **Overview**
> Adds a new `Volleyball Team Leaders` team definition to the Meet Our Teams page so members tagged with `Volleyball` render under their own section with a dedicated description.
> 
> Updates page `metadata`/OpenGraph descriptions to include Volleyball, and extends the Teams page test suite to assert the Volleyball section renders (title, description text, and member item) when matching members are returned.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98d7e4d566c7980253cf78d49761c3da80c0a1c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->