### PR TITLE
fix: semons list item showing incorrect date

### DIFF
--- a/app/sermons/sermon-item.tsx
+++ b/app/sermons/sermon-item.tsx
@@ -14,7 +14,20 @@ export default function SermonItem({
   isLast = false,
 }: SermonItemProps) {
   const formatDate = (date: Date | string) => {
-    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    let dateObj: Date;
+    if (typeof date === 'string') {
+      // Sanity date-only strings (YYYY-MM-DD) are parsed as UTC midnight,
+      // which shifts to previous day in western timezones. Parse as local date.
+      const match = date.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (match) {
+        const [, y, m, d] = match;
+        dateObj = new Date(Number(y), Number(m) - 1, Number(d));
+      } else {
+        dateObj = new Date(date);
+      }
+    } else {
+      dateObj = date;
+    }
     return dateObj.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',


### PR DESCRIPTION
provide a fix to issue: https://github.com/Poiema-Ministries/church-website/issues/21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client-side date parsing/formatting; main risk is edge-case parsing differences for unexpected date string formats.
> 
> **Overview**
> Fixes an off-by-one-day display bug in the sermons list by updating `SermonItem`’s `formatDate` to treat `YYYY-MM-DD` date-only strings as *local* dates instead of relying on `new Date(string)` (UTC midnight parsing).
> 
> For non-date-only strings and `Date` inputs, it preserves existing parsing/formatting behavior and still renders using `toLocaleDateString('en-US')`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1bb0aa319f451979b0a5e4f4d4f5f4bc2d8145. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->