### PR TITLE
feat: upcoming events

### DIFF
--- a/app/api/upcoming-event/route.ts
+++ b/app/api/upcoming-event/route.ts
@@ -1,0 +1,125 @@
+// Copyright 2025 Poiema Ministries. All Rights Reserved.
+
+import { NextResponse } from 'next/server';
+import { Resend } from 'resend';
+import { generateUpcomingEventEmail } from '@/app/common/utils/email-templates';
+import {
+  isHoneypotFilled,
+  isSubmissionTooFast,
+  isSuspiciousMessage,
+} from '@/lib/spam-validation';
+import { client } from '@/sanity/lib/client';
+import { groq } from 'next-sanity';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+/**
+ * Checks if the registration deadline has passed for the given event.
+ * Returns true if the deadline is still open, false if it has passed.
+ */
+async function isRegistrationOpen(eventId: string): Promise<boolean> {
+  const event = await client.fetch(
+    groq`*[_type == "upcomingEvent" && _id == $eventId][0] { registrationDeadline }`,
+    { eventId },
+  );
+
+  if (!event || !event.registrationDeadline) {
+    return false;
+  }
+
+  const deadlineEnd = new Date(event.registrationDeadline + 'T23:59:59');
+  return new Date() <= deadlineEnd;
+}
+
+export async function POST(req: Request) {
+  try {
+    const requestData = await req.json();
+
+    if (!requestData) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 },
+      );
+    }
+
+    // Spam checks
+    if (isHoneypotFilled(requestData)) {
+      return NextResponse.json(
+        { error: 'Invalid submission' },
+        { status: 400 },
+      );
+    }
+    if (isSubmissionTooFast(requestData.formLoadedAt)) {
+      return NextResponse.json(
+        { error: 'Invalid submission' },
+        { status: 400 },
+      );
+    }
+
+    const { eventTitle, eventId, fields } = requestData;
+
+    if (!eventTitle || !eventId || !fields || typeof fields !== 'object') {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 },
+      );
+    }
+
+    // Server-side deadline verification - prevents submissions even if
+    // client-side checks are bypassed
+    const registrationOpen = await isRegistrationOpen(eventId);
+    if (!registrationOpen) {
+      return NextResponse.json(
+        { error: 'Registration for this event has closed' },
+        { status: 403 },
+      );
+    }
+
+    // Validate that all fields have values
+    const fieldEntries = Object.entries(fields) as [string, string][];
+    if (fieldEntries.length === 0) {
+      return NextResponse.json(
+        { error: 'No form fields provided' },
+        { status: 400 },
+      );
+    }
+
+    for (const [label, value] of fieldEntries) {
+      if (!value || String(value).trim().length === 0) {
+        return NextResponse.json(
+          { error: `${label} is required` },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Check field values for spam patterns
+    for (const [, value] of fieldEntries) {
+      if (isSuspiciousMessage(String(value))) {
+        return NextResponse.json(
+          { error: 'Invalid submission' },
+          { status: 400 },
+        );
+      }
+    }
+
+    const html = generateUpcomingEventEmail({
+      eventTitle,
+      fields,
+    });
+
+    await resend.emails.send({
+      from: 'Poiema Ministries Website <onboarding@resend.dev>',
+      to: 'info@poiemaministries.org',
+      subject: `Event Registration: ${eventTitle}`,
+      html,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Email error:', error);
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to send email';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}

--- a/app/common/types/models.ts
+++ b/app/common/types/models.ts
@@ -53,3 +53,33 @@ export interface TeamMember {
   };
   team: string[];
 }
+
+export interface EventFormField {
+  _key: string;
+  label: string;
+  inputType: 'text' | 'textarea' | 'dropdown';
+  dropdownOptions?: string[];
+}
+
+export interface UpcomingEvent {
+  _id: string;
+  title: string;
+  slug: {
+    current: string;
+  };
+  bannerImage: {
+    asset?: {
+      _id: string;
+      url: string;
+    };
+    hotspot?: {
+      x: number;
+      y: number;
+    };
+  };
+  description?: string;
+  eventDate: string;
+  registrationDeadline: string;
+  fields: EventFormField[];
+  order: number;
+}

--- a/app/common/utils/email-templates.ts
+++ b/app/common/utils/email-templates.ts
@@ -191,6 +191,35 @@ export function generateNewMemberEmail(data: {
 }
 
 /**
+ * Generate upcoming event registration email
+ */
+export function generateUpcomingEventEmail(data: {
+  eventTitle: string;
+  fields: Record<string, string>;
+}): string {
+  const fieldEntries = Object.entries(data.fields);
+
+  const fieldsHtml = fieldEntries
+    .map(([label, value], index) => {
+      const style =
+        index === 0 ? EMAIL_STYLES.fieldFirst : EMAIL_STYLES.field;
+      return `
+        <p style="${style}">
+          <strong>${label}:</strong><br/>
+          <span style="${EMAIL_STYLES.content}">${value}</span>
+        </p>
+      `;
+    })
+    .join('');
+
+  return generateEmailTemplate({
+    title: `Event Registration: ${data.eventTitle}`,
+    introText: `A new registration has been submitted for <strong>${data.eventTitle}</strong> through the Poiema Ministries website. Below are the details:`,
+    content: fieldsHtml,
+  });
+}
+
+/**
  * Generate prayer request email
  */
 export function generatePrayerRequestEmail(data: {

--- a/app/upcoming-events/[slug]/event-registration-form.tsx
+++ b/app/upcoming-events/[slug]/event-registration-form.tsx
@@ -1,0 +1,320 @@
+// Copyright 2025 Poiema Ministries. All Rights Reserved.
+
+'use client';
+
+import { useState, useEffect } from 'react';
+import { FieldValues, useForm } from 'react-hook-form';
+import { HONEYPOT_FIELD_NAME } from '@/lib/spam-validation';
+import { UpcomingEvent } from '@/app/common/types/models';
+import Form from '@/app/common/components/form/form';
+import Input from '@/app/common/components/input/input';
+import Textarea from '@/app/common/components/textarea/textarea';
+import Select from '@/app/common/components/select/select';
+import AlertModal from '@/app/common/components/alert-modal/alert-modal';
+
+interface EventRegistrationFormProps {
+  event: UpcomingEvent;
+}
+
+/**
+ * Formats a date string (YYYY-MM-DD) into a readable format.
+ * e.g. "2025-07-15" -> "July 15, 2025"
+ */
+function formatEventDate(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Converts a field label to a safe form field name.
+ * e.g. "First Name" -> "first-name", "Phone Number" -> "phone-number"
+ */
+function labelToFieldName(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+export default function EventRegistrationForm({
+  event,
+}: EventRegistrationFormProps) {
+  const [formLoadedAt, setFormLoadedAt] = useState<number | null>(null);
+  useEffect(() => {
+    const id = setTimeout(() => setFormLoadedAt(Date.now()), 0);
+    return () => clearTimeout(id);
+  }, []);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm();
+
+  const [alertModal, setAlertModal] = useState<{
+    isOpen: boolean;
+    type: 'success' | 'error';
+    title: string;
+    message: string;
+  }>({
+    isOpen: false,
+    type: 'success',
+    title: '',
+    message: '',
+  });
+
+  const onFormSubmit = async (data: FieldValues) => {
+    try {
+      // Build a clean submission object with labels as keys
+      const fields: Record<string, string> = {};
+      for (const field of event.fields) {
+        const fieldName = labelToFieldName(field.label);
+        fields[field.label] = data[fieldName] || '';
+      }
+
+      const formData = {
+        eventTitle: event.title,
+        eventId: event._id,
+        fields,
+        formLoadedAt: formLoadedAt ?? 0,
+        [HONEYPOT_FIELD_NAME]: data[HONEYPOT_FIELD_NAME],
+      };
+
+      const response = await fetch('/api/upcoming-event', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(formData),
+      });
+
+      await response.json();
+
+      if (!response.ok) {
+        setAlertModal({
+          isOpen: true,
+          type: 'error',
+          title: 'Registration Not Sent',
+          message:
+            'We apologize, but we encountered an issue sending your registration. Please try again, or feel free to reach out to us directly. Thank you for your patience!',
+        });
+      } else {
+        reset();
+        setAlertModal({
+          isOpen: true,
+          type: 'success',
+          title: 'Registration Received!',
+          message: `Thank you for registering for ${event.title}! We have received your information and look forward to seeing you there. God bless you!`,
+        });
+      }
+    } catch {
+      setAlertModal({
+        isOpen: true,
+        type: 'error',
+        title: 'Connection Issue',
+        message:
+          'We apologize, but we are having trouble connecting right now. Please check your internet connection and try again. Thank you for your patience!',
+      });
+    }
+  };
+
+  return (
+    <Form
+      headerConfig={{
+        title: event.title,
+        description:
+          event.description ||
+          'Please fill out the form below to register for this event.',
+      }}
+      onFormSubmit={handleSubmit(onFormSubmit)}
+    >
+      {/* Event date and deadline info */}
+      <div className='flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-6 mt-4 mb-2 text-sm text-primary-black/70'>
+        <span>
+          <strong className='text-primary-black'>Event Date:</strong>{' '}
+          {formatEventDate(event.eventDate)}
+        </span>
+        <span className='hidden sm:inline text-primary-black/30'>|</span>
+        <span>
+          <strong className='text-primary-black'>Register By:</strong>{' '}
+          {formatEventDate(event.registrationDeadline)}
+        </span>
+      </div>
+
+      {/* Honeypot - hidden from users, bots fill it */}
+      <div
+        className='absolute -left-[9999px] w-px h-px overflow-hidden'
+        aria-hidden='true'
+      >
+        <label htmlFor={HONEYPOT_FIELD_NAME}>Leave this field empty</label>
+        <input
+          type='text'
+          id={HONEYPOT_FIELD_NAME}
+          tabIndex={-1}
+          autoComplete='off'
+          {...register(HONEYPOT_FIELD_NAME)}
+        />
+      </div>
+
+      <div className='flex flex-col gap-4 w-full mt-5 mb-5'>
+        {event.fields.map((field, index) => {
+          const fieldName = labelToFieldName(field.label);
+          const errorMessage = errors[fieldName]?.message as string;
+
+          // Group consecutive text fields in pairs for side-by-side layout
+          const nextField = event.fields[index + 1];
+          const isTextField = field.inputType === 'text';
+          const nextIsTextField = nextField?.inputType === 'text';
+
+          // Pair logic: group text inputs in rows of 2 when consecutive
+          const shouldStartRow =
+            isTextField &&
+            nextIsTextField &&
+            !isSecondInConsecutiveGroup(event.fields, index);
+          const isSecondInRow =
+            isTextField && isSecondInConsecutiveGroup(event.fields, index);
+
+          if (field.inputType === 'textarea') {
+            return (
+              <div key={field._key} className='flex flex-col gap-4 w-full mt-1'>
+                <Textarea
+                  label={field.label}
+                  placeholder={`Enter ${field.label.toLowerCase()}`}
+                  error={errorMessage}
+                  {...register(fieldName, {
+                    required: `${field.label} is required`,
+                  })}
+                />
+              </div>
+            );
+          }
+
+          if (field.inputType === 'dropdown' && field.dropdownOptions) {
+            const options = field.dropdownOptions.map((option) => ({
+              label: option,
+              value: option,
+            }));
+
+            return (
+              <div key={field._key} className='flex flex-col sm:flex-row gap-4 sm:gap-2'>
+                <div className='flex-1'>
+                  <Select
+                    label={field.label}
+                    placeholder={`Select ${field.label.toLowerCase()}`}
+                    options={options}
+                    error={errorMessage}
+                    {...register(fieldName, {
+                      required: `${field.label} is required`,
+                    })}
+                  />
+                </div>
+              </div>
+            );
+          }
+
+          // Text input field
+          if (shouldStartRow) {
+            // Start a row with two text fields side by side
+            const nextFieldName = labelToFieldName(nextField.label);
+            const nextErrorMessage = errors[nextFieldName]?.message as string;
+
+            return (
+              <div
+                key={field._key}
+                className='flex flex-col sm:flex-row gap-4 sm:gap-2'
+              >
+                <div className='flex-1'>
+                  <Input
+                    label={field.label}
+                    type='text'
+                    error={errorMessage}
+                    {...register(fieldName, {
+                      required: `${field.label} is required`,
+                    })}
+                  />
+                </div>
+                <div className='flex-1'>
+                  <Input
+                    label={nextField.label}
+                    type='text'
+                    error={nextErrorMessage}
+                    {...register(nextFieldName, {
+                      required: `${nextField.label} is required`,
+                    })}
+                  />
+                </div>
+              </div>
+            );
+          }
+
+          if (isSecondInRow) {
+            // Already rendered as part of the previous pair
+            return null;
+          }
+
+          // Single text field (odd one out or standalone)
+          return (
+            <div key={field._key} className='flex flex-col sm:flex-row gap-4 sm:gap-2'>
+              <div className='flex-1'>
+                <Input
+                  label={field.label}
+                  type='text'
+                  error={errorMessage}
+                  {...register(fieldName, {
+                    required: `${field.label} is required`,
+                  })}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <AlertModal
+        isOpen={alertModal.isOpen}
+        type={alertModal.type}
+        title={alertModal.title}
+        message={alertModal.message}
+        onClose={() =>
+          setAlertModal({
+            ...alertModal,
+            isOpen: false,
+          })
+        }
+        autoClose={alertModal.type === 'success'}
+        autoCloseDelay={7000}
+      />
+    </Form>
+  );
+}
+
+/**
+ * Determines if the field at the given index is the second in a consecutive
+ * group of text fields. Used for pairing text inputs side by side.
+ */
+function isSecondInConsecutiveGroup(
+  fields: { inputType: string }[],
+  index: number,
+): boolean {
+  if (index === 0) return false;
+
+  const current = fields[index];
+  const prev = fields[index - 1];
+
+  if (current.inputType !== 'text' || prev.inputType !== 'text') return false;
+
+  // Count how many consecutive text fields precede this one (including current)
+  let consecutiveCount = 0;
+  for (let i = index; i >= 0 && fields[i].inputType === 'text'; i--) {
+    consecutiveCount++;
+  }
+
+  // If the consecutive count (from start of group to current) is even,
+  // this is the second of a pair
+  return consecutiveCount % 2 === 0;
+}

--- a/app/upcoming-events/[slug]/page.tsx
+++ b/app/upcoming-events/[slug]/page.tsx
@@ -1,0 +1,118 @@
+// Copyright 2025 Poiema Ministries. All Rights Reserved.
+
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { client } from '@/sanity/lib/client';
+import { upcomingEventBySlugQuery } from '@/sanity/lib/queries';
+import { UpcomingEvent } from '@/app/common/types/models';
+import EventRegistrationForm from './event-registration-form';
+
+export const revalidate = 0;
+export const dynamic = 'force-dynamic';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+/**
+ * Checks if the registration deadline has passed.
+ * Compares against the end of the deadline day (23:59:59) to allow
+ * registrations for the entire final day.
+ */
+function isRegistrationClosed(registrationDeadline: string): boolean {
+  const deadlineEnd = new Date(registrationDeadline + 'T23:59:59');
+  return new Date() > deadlineEnd;
+}
+
+/**
+ * Formats a date string (YYYY-MM-DD) into a readable format.
+ * e.g. "2025-07-15" -> "July 15, 2025"
+ */
+function formatEventDate(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const event: UpcomingEvent | null = await client.fetch(
+    upcomingEventBySlugQuery,
+    { slug },
+  );
+
+  if (!event) {
+    return {
+      title: 'Event Not Found',
+    };
+  }
+
+  return {
+    title: `${event.title} | Poiema Ministries`,
+    description:
+      event.description ||
+      `Register for ${event.title} at Poiema Ministries.`,
+    openGraph: {
+      title: `${event.title} | Poiema Ministries`,
+      description:
+        event.description ||
+        `Register for ${event.title} at Poiema Ministries.`,
+    },
+  };
+}
+
+export default async function EventPage({ params }: PageProps) {
+  const { slug } = await params;
+  const event: UpcomingEvent | null = await client.fetch(
+    upcomingEventBySlugQuery,
+    { slug },
+  );
+
+  if (!event) {
+    notFound();
+  }
+
+  // Server-side deadline guard: if registration is closed, show a message
+  if (isRegistrationClosed(event.registrationDeadline)) {
+    return (
+      <div className='flex flex-col w-full bg-background py-12 sm:py-16 md:py-20'>
+        <div className='flex flex-col items-center justify-center w-full max-w-2xl mx-auto px-4 sm:px-6 md:px-8 text-center'>
+          <h1 className='text-2xl sm:text-3xl font-bold text-primary-black'>
+            {event.title}
+          </h1>
+          <p className='text-sm sm:text-base text-primary-black/70 mt-2'>
+            {formatEventDate(event.eventDate)}
+          </p>
+          <div className='mt-6 sm:mt-8 p-6 sm:p-8 border border-primary-black/15 rounded-md bg-secondary/50'>
+            <p className='text-base sm:text-lg text-primary-black font-semibold'>
+              Registration Closed
+            </p>
+            <p className='text-sm sm:text-base text-primary-black/70 mt-2 leading-relaxed'>
+              We&apos;re sorry, but registration for this event closed on{' '}
+              {formatEventDate(event.registrationDeadline)}. If you have any
+              questions, please feel free to contact us directly.
+            </p>
+          </div>
+          <Link
+            href='/upcoming-events'
+            className='mt-6 text-sm font-semibold text-primary-black underline underline-offset-2 hover:text-primary-black/70 transition-colors'
+          >
+            View Upcoming Events
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col w-full bg-background py-8 sm:py-10 md:py-12'>
+      <EventRegistrationForm event={event} />
+    </div>
+  );
+}

--- a/app/upcoming-events/page.tsx
+++ b/app/upcoming-events/page.tsx
@@ -1,0 +1,90 @@
+// Copyright 2025 Poiema Ministries. All Rights Reserved.
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { client } from '@/sanity/lib/client';
+import { upcomingEventsQuery } from '@/sanity/lib/queries';
+import { urlFor } from '@/sanity/lib/image';
+import { UpcomingEvent } from '../common/types/models';
+
+export const revalidate = 0;
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Upcoming Events',
+  description:
+    'View and register for upcoming events at Poiema Ministries. Join us for fellowship, worship, and community gatherings.',
+  openGraph: {
+    title: 'Upcoming Events | Poiema Ministries',
+    description:
+      'View and register for upcoming events at Poiema Ministries. Join us for fellowship, worship, and community gatherings.',
+  },
+};
+
+/**
+ * Formats a date string (YYYY-MM-DD) into a readable format.
+ * e.g. "2025-07-15" -> "July 15, 2025"
+ */
+function formatEventDate(dateString: string): string {
+  const date = new Date(dateString + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default async function UpcomingEvents() {
+  const events: UpcomingEvent[] = await client.fetch(upcomingEventsQuery);
+
+  return (
+    <div className='flex flex-col w-full bg-background'>
+      <div className='flex flex-col items-center md:items-start w-full max-w-7xl mx-auto px-4 sm:px-6 md:px-8 lg:px-12 pt-8 sm:pt-10 md:pt-12'>
+        <h1 className='text-4xl font-bold text-center mt-2'>
+          Upcoming Events
+        </h1>
+      </div>
+
+      {events.length > 0 ? (
+        <div className='flex flex-col w-full mt-6 sm:mt-8 pb-8 sm:pb-10 md:pb-12'>
+          {events.map((event) => (
+            <Link
+              key={event._id}
+              href={`/upcoming-events/${event.slug.current}`}
+              className='group relative block w-full overflow-hidden'
+            >
+              <div className='relative w-full aspect-[16/9] sm:aspect-[4/1]'>
+                <Image
+                  src={urlFor(event.bannerImage).width(1920).quality(85).url()}
+                  alt={event.title}
+                  fill
+                  className='object-cover transition-transform duration-500 group-hover:scale-[1.03]'
+                  sizes='100vw'
+                  priority
+                />
+                {/* Black overlay */}
+                <div className='absolute inset-0 bg-black/55' />
+                {/* Title and date overlay */}
+                <div className='absolute inset-0 flex flex-col items-center justify-center px-4 gap-2'>
+                  <h2 className='text-white text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-center drop-shadow-lg group-hover:underline underline-offset-4'>
+                    {event.title}
+                  </h2>
+                  <p className='text-white/90 text-sm sm:text-base md:text-lg font-medium drop-shadow-md'>
+                    {formatEventDate(event.eventDate)}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className='flex items-center justify-center py-16 sm:py-24'>
+          <p className='text-lg text-primary-black/70'>
+            No upcoming events at this time. Check back soon!
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -57,3 +57,47 @@ export const teamMembersQuery = groq`
     team
   }
 `;
+
+export const upcomingEventsQuery = groq`
+  *[_type == "upcomingEvent" && registrationDeadline >= now()] | order(order asc) {
+    _id,
+    title,
+    slug,
+    bannerImage {
+      asset,
+      hotspot
+    },
+    description,
+    eventDate,
+    registrationDeadline,
+    fields[] {
+      _key,
+      label,
+      inputType,
+      dropdownOptions
+    },
+    order
+  }
+`;
+
+export const upcomingEventBySlugQuery = groq`
+  *[_type == "upcomingEvent" && slug.current == $slug][0] {
+    _id,
+    title,
+    slug,
+    bannerImage {
+      asset,
+      hotspot
+    },
+    description,
+    eventDate,
+    registrationDeadline,
+    fields[] {
+      _key,
+      label,
+      inputType,
+      dropdownOptions
+    },
+    order
+  }
+`;

--- a/sanity/schemaTypes/upcomingEventType.ts
+++ b/sanity/schemaTypes/upcomingEventType.ts
@@ -1,23 +1,177 @@
 // Copyright 2025 Poiema Ministries. All Rights Reserved.
 
-import { type SchemaTypeDefinition } from 'sanity';
+import { defineField, defineType } from 'sanity';
 
-export const upcomingEventType: SchemaTypeDefinition = {
-  name: 'upcomingEventType',
-  title: 'Upcoming Event Type',
+export const upcomingEventType = defineType({
+  name: 'upcomingEvent',
+  title: 'Upcoming Event',
   type: 'document',
   fields: [
-    { name: 'title', title: 'Title', type: 'string' },
-    { name: 'description', title: 'Description', type: 'text' },
-    { name: 'nameRequired', title: 'Name Required', type: 'boolean' },
-    { name: 'emailRequired', title: 'Email Required', type: 'boolean' },
-    { name: 'phoneRequired', title: 'Phone Required', type: 'boolean' },
-    { name: 'order', title: 'Order', type: 'number' },
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'The title of the upcoming event',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      description:
+        'URL-friendly identifier for the event (click Generate to create from the title)',
+      options: {
+        source: 'title',
+        maxLength: 96,
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'bannerImage',
+      title: 'Banner Image',
+      type: 'image',
+      description: 'The banner image displayed on the upcoming events page',
+      options: {
+        hotspot: true,
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'text',
+      description: 'A description of the event (optional)',
+      rows: 4,
+    }),
+    defineField({
+      name: 'eventDate',
+      title: 'Event Date',
+      type: 'date',
+      description: 'The date the event is happening',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'registrationDeadline',
+      title: 'Registration Deadline',
+      type: 'date',
+      description:
+        'The last day to register for the event. After this date, the event will no longer appear on the website and the registration form will be closed.',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'fields',
+      title: 'Form Fields',
+      type: 'array',
+      description:
+        'The input fields that will appear on the event registration form. Each field requires a label and an input type.',
+      of: [
+        {
+          type: 'object',
+          name: 'formField',
+          title: 'Form Field',
+          fields: [
+            defineField({
+              name: 'label',
+              title: 'Field Label',
+              type: 'string',
+              description:
+                'The label displayed above the input (e.g., "First Name", "Phone Number")',
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'inputType',
+              title: 'Input Type',
+              type: 'string',
+              description: 'The type of input field',
+              options: {
+                list: [
+                  { title: 'Text', value: 'text' },
+                  { title: 'Textarea', value: 'textarea' },
+                  { title: 'Dropdown', value: 'dropdown' },
+                ],
+                layout: 'radio',
+              },
+              initialValue: 'text',
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'dropdownOptions',
+              title: 'Dropdown Options',
+              type: 'array',
+              description:
+                'The selectable options for the dropdown. Only used when Input Type is set to "Dropdown".',
+              of: [{ type: 'string' }],
+              hidden: ({ parent }) => parent?.inputType !== 'dropdown',
+              validation: (rule) =>
+                rule.custom((value, context) => {
+                  const parent = context.parent as
+                    | { inputType?: string }
+                    | undefined;
+                  if (
+                    parent?.inputType === 'dropdown' &&
+                    (!Array.isArray(value) || value.length < 2)
+                  ) {
+                    return 'Dropdown fields require at least 2 options';
+                  }
+                  return true;
+                }),
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'label',
+              subtitle: 'inputType',
+              options: 'dropdownOptions',
+            },
+            prepare({ title, subtitle, options }) {
+              const typeLabel = subtitle || 'text';
+              const optionCount =
+                subtitle === 'dropdown' && Array.isArray(options)
+                  ? ` (${options.length} options)`
+                  : '';
+              return {
+                title: title || 'Untitled Field',
+                subtitle: `Type: ${typeLabel}${optionCount}`,
+              };
+            },
+          },
+        },
+      ],
+      validation: (rule) =>
+        rule.min(1).error('At least one form field is required'),
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      description:
+        'Order in which this event should be displayed (lower numbers appear first)',
+      validation: (rule) => rule.required().integer().min(1),
+    }),
   ],
   preview: {
     select: {
       title: 'title',
-      subtitle: 'description',
+      eventDate: 'eventDate',
+      registrationDeadline: 'registrationDeadline',
+      media: 'bannerImage',
+    },
+    prepare({ title, eventDate, registrationDeadline, media }) {
+      const parts: string[] = [];
+      if (eventDate) parts.push(`Event: ${eventDate}`);
+      if (registrationDeadline) parts.push(`Deadline: ${registrationDeadline}`);
+      return {
+        title: title || 'Untitled Event',
+        subtitle: parts.length > 0 ? parts.join(' | ') : 'No dates set',
+        media,
+      };
     },
   },
-};
+  orderings: [
+    {
+      title: 'Order, Ascending',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+});


### PR DESCRIPTION
add upcoming events. people who have access to the admin page can generate upcoming event forms which will dynamically be loaded to the upcoming events page. based off of the information given, will load the form with all the required inputs that are needed along with validation and will send to the poiema email