### PR TITLE
feat(retreat): group & buddy questions section

### DIFF
--- a/__tests__/app/retreat/page.test.tsx
+++ b/__tests__/app/retreat/page.test.tsx
@@ -49,6 +49,8 @@ jest.mock('@/sanity/lib/image', () => ({
 const mockRetreat = {
   _id: 'retreat',
   isEnabled: true,
+  areGroupsVisible: true,
+  areBuddyQuestionsVisible: true,
   themeTitle: 'Comfort My People',
   subtitle: 'Winter Retreat 2026',
   speaker: 'Pastor Samuel Jung',
@@ -87,6 +89,24 @@ const mockRetreat = {
         },
       ],
     },
+  ],
+  groups: [
+    {
+      _key: 'group-1',
+      name: 'Group 1',
+      leader: 'Grace Yuen',
+      members: ['Kenneth Kim', 'Isaac Jeong', 'Samuel Lee'],
+    },
+    {
+      _key: 'group-2',
+      name: 'Group 2',
+      leader: 'Paul Ball',
+      members: ['Woojin Kim', 'Vincent Jeong'],
+    },
+  ],
+  buddyQuestions: [
+    'Introduce yourself and share some fun facts about yourself (hobbies, job, major, etc.)!',
+    'Rank 3 Things: Chicken, Beef, Pork',
   ],
   questionSections: [
     {
@@ -133,7 +153,7 @@ describe('Retreat Page', () => {
     expect(notFound).toHaveBeenCalled();
   });
 
-  it('renders theme, schedule, and visible questions', async () => {
+  it('renders theme, schedule, groups, buddy questions, and visible questions', async () => {
     mockFetch.mockResolvedValue(mockRetreat);
 
     const component = await RetreatPage();
@@ -150,6 +170,20 @@ describe('Retreat Page', () => {
     expect(screen.getByText('Friday')).toBeInTheDocument();
     expect(screen.getByText('Departure')).toBeInTheDocument();
     expect(screen.getByText('8:30 AM – 9:00 AM')).toBeInTheDocument();
+    expect(screen.getByText('Groups')).toBeInTheDocument();
+    expect(screen.getByText('Group 1')).toBeInTheDocument();
+    expect(screen.getByText('Grace Yuen')).toBeInTheDocument();
+    expect(screen.getByText('Kenneth Kim')).toBeInTheDocument();
+    expect(screen.getByText('Paul Ball')).toBeInTheDocument();
+    expect(screen.getByText('Buddy Questions')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Introduce yourself and share some fun facts about yourself (hobbies, job, major, etc.)!',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Rank 3 Things: Chicken, Beef, Pork'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Reflection Questions')).toBeInTheDocument();
     expect(screen.getByText('Isaiah 40:1')).toBeInTheDocument();
     expect(
@@ -190,5 +224,46 @@ describe('Retreat Page', () => {
     render(component);
 
     expect(screen.getByText('Schedule coming soon.')).toBeInTheDocument();
+  });
+
+  it('hides groups section when no groups are configured', async () => {
+    mockFetch.mockResolvedValue({
+      ...mockRetreat,
+      groups: [],
+    });
+
+    const component = await RetreatPage();
+    render(component);
+
+    expect(screen.queryByText('Groups')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grace Yuen')).not.toBeInTheDocument();
+  });
+
+  it('hides groups section when the groups toggle is off', async () => {
+    mockFetch.mockResolvedValue({
+      ...mockRetreat,
+      areGroupsVisible: false,
+    });
+
+    const component = await RetreatPage();
+    render(component);
+
+    expect(screen.queryByText('Groups')).not.toBeInTheDocument();
+    expect(screen.queryByText('Grace Yuen')).not.toBeInTheDocument();
+  });
+
+  it('hides buddy questions when the toggle is off', async () => {
+    mockFetch.mockResolvedValue({
+      ...mockRetreat,
+      areBuddyQuestionsVisible: false,
+    });
+
+    const component = await RetreatPage();
+    render(component);
+
+    expect(screen.queryByText('Buddy Questions')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Rank 3 Things: Chicken, Beef, Pork'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/common/types/models.ts
+++ b/app/common/types/models.ts
@@ -126,6 +126,13 @@ export interface RetreatQuestionSection {
   reflectionQuestions: string[];
 }
 
+export interface RetreatGroup {
+  _key: string;
+  name?: string;
+  leader: string;
+  members: string[];
+}
+
 export interface Retreat {
   _id: string;
   isEnabled: boolean;
@@ -143,5 +150,9 @@ export interface Retreat {
     };
   };
   scheduleDays?: RetreatScheduleDay[];
+  areGroupsVisible?: boolean;
+  groups?: RetreatGroup[];
+  areBuddyQuestionsVisible?: boolean;
+  buddyQuestions?: string[];
   questionSections?: RetreatQuestionSection[];
 }

--- a/app/retreat/page.tsx
+++ b/app/retreat/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/sanity/lib/cache';
 import {
   Retreat,
+  RetreatGroup,
   RetreatQuestionSection,
   RetreatScheduleDay,
 } from '../common/types/models';
@@ -23,11 +24,11 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = {
   title: 'Retreat',
   description:
-    'View the schedule, theme, and reflection questions for the Poiema Ministries retreat.',
+    'View the schedule, groups, buddy questions, theme, and reflection questions for the Poiema Ministries retreat.',
   openGraph: {
     title: 'Retreat | Poiema Ministries',
     description:
-      'View the schedule, theme, and reflection questions for the Poiema Ministries retreat.',
+      'View the schedule, groups, buddy questions, theme, and reflection questions for the Poiema Ministries retreat.',
   },
 };
 
@@ -117,7 +118,7 @@ function BiblePassage({ text }: { text: string }) {
         <p className='text-base sm:text-lg leading-[1.9] text-primary-black'>
           {verses.map((verse, index) => (
             <span key={`${verse.number}-${index}`}>
-              {index > 0 ? (verse.lines.length > 1 ? <br /> : ' ') : null}
+              {index > 0 ? verse.lines.length > 1 ? <br /> : ' ' : null}
               <sup className='mr-1 select-none text-[0.7em] font-semibold text-primary-black/45 align-super'>
                 {verse.number}
               </sup>
@@ -136,6 +137,44 @@ function BiblePassage({ text }: { text: string }) {
         </p>
       )}
     </blockquote>
+  );
+}
+
+function groupsGridClass(count: number) {
+  if (count <= 1) return 'grid-cols-1';
+  if (count === 2) return 'grid-cols-1 sm:grid-cols-2';
+  if (count === 3) return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3';
+  if (count === 4) return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4';
+  return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5';
+}
+
+function GroupCard({ group, index }: { group: RetreatGroup; index: number }) {
+  const groupName = group.name?.trim() || `Group ${index + 1}`;
+
+  return (
+    <article className='flex flex-col min-w-0 border border-primary-black/15 bg-background'>
+      <header className='bg-secondary px-4 py-3 border-b border-primary-black/15'>
+        <p className='text-xs tracking-wide uppercase text-primary-black/60'>
+          {groupName}
+        </p>
+        <h3 className='mt-1 text-lg sm:text-xl font-bold text-primary-black leading-tight'>
+          {group.leader}
+        </h3>
+        <p className='mt-0.5 text-xs sm:text-sm text-primary-black/70'>
+          Leader
+        </p>
+      </header>
+      <ul className='px-4 py-4 space-y-2.5'>
+        {group.members?.map((member, memberIndex) => (
+          <li
+            key={`${group._key}-${memberIndex}`}
+            className='text-sm sm:text-base text-primary-black leading-relaxed'
+          >
+            {member}
+          </li>
+        ))}
+      </ul>
+    </article>
   );
 }
 
@@ -168,18 +207,26 @@ function QuestionSection({ section }: { section: RetreatQuestionSection }) {
 export default async function RetreatPage() {
   const retreat: Retreat | null = await client
     .withConfig({ useCdn: false })
-    .fetch(retreatQuery, {}, {
-      next: {
-        revalidate: SANITY_RETREAT_REVALIDATE_SECONDS,
-        tags: [SANITY_TAGS.retreat, SANITY_TAGS.all],
+    .fetch(
+      retreatQuery,
+      {},
+      {
+        next: {
+          revalidate: SANITY_RETREAT_REVALIDATE_SECONDS,
+          tags: [SANITY_TAGS.retreat, SANITY_TAGS.all],
+        },
       },
-    });
+    );
 
   if (!retreat?.isEnabled) {
     notFound();
   }
 
   const scheduleDays = retreat.scheduleDays ?? [];
+  const groups = retreat.areGroupsVisible ? (retreat.groups ?? []) : [];
+  const buddyQuestions = retreat.areBuddyQuestionsVisible
+    ? (retreat.buddyQuestions ?? [])
+    : [];
   const visibleSections =
     retreat.questionSections?.filter((section) => section.isVisible) ?? [];
 
@@ -213,6 +260,45 @@ export default async function RetreatPage() {
 
           <ThemePanel retreat={retreat} className='hidden md:flex' />
         </div>
+
+        {groups.length > 0 && (
+          <section
+            aria-label='Retreat groups'
+            className='mt-14 sm:mt-16 md:mt-20 pt-10 border-t border-primary-black/20'
+          >
+            <h2 className='text-2xl sm:text-3xl font-bold text-primary-black mb-8'>
+              Groups
+            </h2>
+            <div
+              className={`grid gap-4 sm:gap-5 ${groupsGridClass(groups.length)}`}
+            >
+              {groups.map((group, index) => (
+                <GroupCard key={group._key} group={group} index={index} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {buddyQuestions.length > 0 && (
+          <section
+            aria-label='Buddy questions'
+            className='mt-14 sm:mt-16 md:mt-20 pt-10 border-t border-primary-black/20'
+          >
+            <h2 className='text-2xl sm:text-3xl font-bold text-primary-black mb-8'>
+              Buddy Questions
+            </h2>
+            <ol className='list-decimal pl-5 space-y-3 max-w-3xl'>
+              {buddyQuestions.map((question, index) => (
+                <li
+                  key={`buddy-${index}`}
+                  className='text-sm sm:text-base text-primary-black leading-relaxed pl-1'
+                >
+                  {question}
+                </li>
+              ))}
+            </ol>
+          </section>
+        )}
 
         {visibleSections.length > 0 && (
           <section

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -147,6 +147,15 @@ export const retreatQuery = groq`
         note
       }
     },
+    areGroupsVisible,
+    groups[] {
+      _key,
+      name,
+      leader,
+      members
+    },
+    areBuddyQuestionsVisible,
+    buddyQuestions,
     questionSections[] {
       _key,
       isVisible,

--- a/sanity/schemaTypes/retreatType.ts
+++ b/sanity/schemaTypes/retreatType.ts
@@ -148,6 +148,83 @@ export const retreatType = defineType({
       ],
     }),
     defineField({
+      name: 'areGroupsVisible',
+      title: 'Show Groups on Retreat Page',
+      type: 'boolean',
+      description:
+        'Turn on to display the Groups section. Leave off to hide it until ready.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'groups',
+      title: 'Groups',
+      type: 'array',
+      description:
+        'Small groups shown after the schedule when "Show Groups on Retreat Page" is on.',
+      of: [
+        {
+          type: 'object',
+          name: 'retreatGroup',
+          title: 'Group',
+          fields: [
+            defineField({
+              name: 'name',
+              title: 'Group Name',
+              type: 'string',
+              description:
+                'e.g., Group 1. Leave blank to number groups automatically.',
+            }),
+            defineField({
+              name: 'leader',
+              title: 'Leader',
+              type: 'string',
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'members',
+              title: 'Members',
+              type: 'array',
+              of: [{ type: 'string' }],
+              validation: (rule) =>
+                rule.min(1).error('Add at least one group member'),
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'name',
+              leader: 'leader',
+              members: 'members',
+            },
+            prepare({ title, leader, members }) {
+              const count = Array.isArray(members) ? members.length : 0;
+              return {
+                title: title || leader || 'Untitled group',
+                subtitle: [leader && `Leader: ${leader}`, `${count} members`]
+                  .filter(Boolean)
+                  .join(' · '),
+              };
+            },
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'areBuddyQuestionsVisible',
+      title: 'Show Buddy Questions on Retreat Page',
+      type: 'boolean',
+      description:
+        'Turn on to display the Buddy Questions section. Leave off to hide it until ready.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'buddyQuestions',
+      title: 'Buddy Questions',
+      type: 'array',
+      description:
+        'Icebreaker questions shown after Groups when "Show Buddy Questions on Retreat Page" is on.',
+      of: [{ type: 'string' }],
+    }),
+    defineField({
       name: 'questionSections',
       title: 'Question Sections',
       type: 'array',


### PR DESCRIPTION
added sections on the retreat page to display discussion groups & buddy questions. changes can be made on the admin page whether it be adding more groups, members, buddy questions and more and both of these sections are controlled by a toggle to have it displayed on the website whenever needed 
<img width="2450" height="1242" alt="image" src="https://github.com/user-attachments/assets/80fd25b1-7f52-4862-823d-7f9c6272ff42" />
<img width="2502" height="958" alt="image" src="https://github.com/user-attachments/assets/782f08bb-208a-4560-a39b-772f228de485" />
