### PR TITLE
feat(retreat): links

### DIFF
--- a/__tests__/app/retreat/page.test.tsx
+++ b/__tests__/app/retreat/page.test.tsx
@@ -51,6 +51,7 @@ const mockRetreat = {
   isEnabled: true,
   areGroupsVisible: true,
   areBuddyQuestionsVisible: true,
+  areLinksVisible: true,
   themeTitle: 'Comfort My People',
   subtitle: 'Winter Retreat 2026',
   speaker: 'Pastor Samuel Jung',
@@ -129,6 +130,25 @@ const mockRetreat = {
       reflectionQuestions: ['Should not appear'],
     },
   ],
+  links: [
+    {
+      _key: 'link-1',
+      isVisible: true,
+      title: 'Sign-up Form',
+      url: 'https://example.com/signup',
+    },
+    {
+      _key: 'link-2',
+      isVisible: true,
+      url: 'https://example.com/notes',
+    },
+    {
+      _key: 'link-3',
+      isVisible: false,
+      title: 'Hidden Link',
+      url: 'https://example.com/hidden',
+    },
+  ],
 };
 
 describe('Retreat Page', () => {
@@ -153,7 +173,7 @@ describe('Retreat Page', () => {
     expect(notFound).toHaveBeenCalled();
   });
 
-  it('renders theme, schedule, groups, buddy questions, and visible questions', async () => {
+  it('renders theme, schedule, groups, buddy questions, visible questions, and links', async () => {
     mockFetch.mockResolvedValue(mockRetreat);
 
     const component = await RetreatPage();
@@ -197,6 +217,18 @@ describe('Retreat Page', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText('Hidden Sermon')).not.toBeInTheDocument();
     expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
+    expect(screen.getByText('Links')).toBeInTheDocument();
+    expect(screen.getByText(/Sign-up Form:/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'https://example.com/signup' }),
+    ).toHaveAttribute('href', 'https://example.com/signup');
+    expect(
+      screen.getByRole('link', { name: 'https://example.com/notes' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Hidden Link:/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'https://example.com/hidden' }),
+    ).not.toBeInTheDocument();
   });
 
   it('hides reflection section when no questions are visible', async () => {
@@ -265,5 +297,18 @@ describe('Retreat Page', () => {
     expect(
       screen.queryByText('Rank 3 Things: Chicken, Beef, Pork'),
     ).not.toBeInTheDocument();
+  });
+
+  it('hides links section when the links toggle is off', async () => {
+    mockFetch.mockResolvedValue({
+      ...mockRetreat,
+      areLinksVisible: false,
+    });
+
+    const component = await RetreatPage();
+    render(component);
+
+    expect(screen.queryByText('Links')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Sign-up Form:/)).not.toBeInTheDocument();
   });
 });

--- a/app/common/types/models.ts
+++ b/app/common/types/models.ts
@@ -133,6 +133,13 @@ export interface RetreatGroup {
   members: string[];
 }
 
+export interface RetreatLink {
+  _key: string;
+  isVisible: boolean;
+  title?: string;
+  url: string;
+}
+
 export interface Retreat {
   _id: string;
   isEnabled: boolean;
@@ -155,4 +162,6 @@ export interface Retreat {
   areBuddyQuestionsVisible?: boolean;
   buddyQuestions?: string[];
   questionSections?: RetreatQuestionSection[];
+  areLinksVisible?: boolean;
+  links?: RetreatLink[];
 }

--- a/app/retreat/page.tsx
+++ b/app/retreat/page.tsx
@@ -13,6 +13,7 @@ import {
 import {
   Retreat,
   RetreatGroup,
+  RetreatLink,
   RetreatQuestionSection,
   RetreatScheduleDay,
 } from '../common/types/models';
@@ -24,11 +25,11 @@ export const dynamic = 'force-dynamic';
 export const metadata: Metadata = {
   title: 'Retreat',
   description:
-    'View the schedule, groups, buddy questions, theme, and reflection questions for the Poiema Ministries retreat.',
+    'View the schedule, groups, buddy questions, theme, reflection questions, and links for the Poiema Ministries retreat.',
   openGraph: {
     title: 'Retreat | Poiema Ministries',
     description:
-      'View the schedule, groups, buddy questions, theme, and reflection questions for the Poiema Ministries retreat.',
+      'View the schedule, groups, buddy questions, theme, reflection questions, and links for the Poiema Ministries retreat.',
   },
 };
 
@@ -178,6 +179,24 @@ function GroupCard({ group, index }: { group: RetreatGroup; index: number }) {
   );
 }
 
+function LinkItem({ link }: { link: RetreatLink }) {
+  const title = link.title?.trim();
+
+  return (
+    <li className='text-sm sm:text-base text-primary-black leading-relaxed break-words pl-1'>
+      {title ? <span className='font-semibold'>{title}: </span> : null}
+      <a
+        href={link.url}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='underline underline-offset-2 hover:text-primary-black/70'
+      >
+        {link.url}
+      </a>
+    </li>
+  );
+}
+
 function QuestionSection({ section }: { section: RetreatQuestionSection }) {
   return (
     <article className='border-t border-primary-black/20 pt-8 first:border-t-0 first:pt-0'>
@@ -229,6 +248,9 @@ export default async function RetreatPage() {
     : [];
   const visibleSections =
     retreat.questionSections?.filter((section) => section.isVisible) ?? [];
+  const links = retreat.areLinksVisible
+    ? (retreat.links?.filter((link) => link.isVisible && link.url) ?? [])
+    : [];
 
   return (
     <div className='flex flex-col w-full bg-background min-h-screen'>
@@ -313,6 +335,22 @@ export default async function RetreatPage() {
                 <QuestionSection key={section._key} section={section} />
               ))}
             </div>
+          </section>
+        )}
+
+        {links.length > 0 && (
+          <section
+            aria-label='Retreat links'
+            className='mt-14 sm:mt-16 md:mt-20 pt-10 border-t border-primary-black/20'
+          >
+            <h2 className='text-2xl sm:text-3xl font-bold text-primary-black mb-8'>
+              Links
+            </h2>
+            <ul className='list-disc pl-5 space-y-3 max-w-3xl'>
+              {links.map((link) => (
+                <LinkItem key={link._key} link={link} />
+              ))}
+            </ul>
           </section>
         )}
       </div>

--- a/sanity/lib/queries.ts
+++ b/sanity/lib/queries.ts
@@ -163,6 +163,13 @@ export const retreatQuery = groq`
       bibleVerse,
       bibleVerseText,
       reflectionQuestions
+    },
+    areLinksVisible,
+    links[] {
+      _key,
+      isVisible,
+      title,
+      url
     }
   }
 `;

--- a/sanity/schemaTypes/retreatType.ts
+++ b/sanity/schemaTypes/retreatType.ts
@@ -290,6 +290,69 @@ export const retreatType = defineType({
         },
       ],
     }),
+    defineField({
+      name: 'areLinksVisible',
+      title: 'Show Links on Retreat Page',
+      type: 'boolean',
+      description:
+        'Turn on to display the Links section. Leave off to hide it until ready.',
+      initialValue: false,
+    }),
+    defineField({
+      name: 'links',
+      title: 'Links',
+      type: 'array',
+      description:
+        'Links shown after Reflection Questions when "Show Links on Retreat Page" is on. Each link also has its own visibility toggle.',
+      of: [
+        {
+          type: 'object',
+          name: 'retreatLink',
+          title: 'Link',
+          fields: [
+            defineField({
+              name: 'isVisible',
+              title: 'Show on Retreat Page',
+              type: 'boolean',
+              description: 'Turn off to hide this link without deleting it.',
+              initialValue: true,
+            }),
+            defineField({
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+              description:
+                'Optional label shown before the URL (e.g., "Sign-up Form").',
+            }),
+            defineField({
+              name: 'url',
+              title: 'Link',
+              type: 'url',
+              description: 'The URL to display (required).',
+              validation: (rule) =>
+                rule.required().uri({
+                  scheme: ['http', 'https'],
+                }),
+            }),
+          ],
+          preview: {
+            select: {
+              title: 'title',
+              url: 'url',
+              isVisible: 'isVisible',
+            },
+            prepare({ title, url, isVisible }) {
+              return {
+                title: title || url || 'Untitled link',
+                subtitle: `${isVisible ? 'Visible' : 'Hidden'}${
+                  url ? ` · ${url}` : ''
+                }`,
+              };
+            },
+          },
+        },
+      ],
+    }),
   ],
   preview: {
     select: {


### PR DESCRIPTION
added a configurable link section which allows users to add specific links in a list for retreat. whether it be needed for games, guides and more. the required parameter to add any link is the link itself, but users can also add a title as well
<img width="801" height="187" alt="IMG_7587" src="https://github.com/user-attachments/assets/7f7cfc6d-7374-4f85-a233-8415850bf45a" />
<img width="957" height="218" alt="IMG_0683" src="https://github.com/user-attachments/assets/31744af8-21d7-45e0-96be-0b0f7deebff2" />
